### PR TITLE
New functionality: one group expanded

### DIFF
--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
@@ -1,5 +1,3 @@
 package com.tempos21.expandablerecycleradapter;
 
-public abstract class ChildMenuItem extends BaseMenuItem {
-    
-}
+public abstract class ChildMenuItem extends BaseMenuItem { }

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
@@ -1,3 +1,5 @@
 package com.tempos21.expandablerecycleradapter;
 
-public abstract class ChildMenuItem extends BaseMenuItem { }
+public abstract class ChildMenuItem extends BaseMenuItem {
+    
+}

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableMenuItem.java
@@ -8,6 +8,8 @@ public class ExpandableMenuItem extends BaseMenuItem {
 
     private boolean expanded = false;
 
+    private ExpandableRecyclerAdapter.Holder holder;
+
     public ExpandableMenuItem() { }
 
     public ExpandableMenuItem(List<ChildMenuItem> children) {
@@ -32,5 +34,13 @@ public class ExpandableMenuItem extends BaseMenuItem {
 
     public void setChildren(List<ChildMenuItem> children) {
         this.children = children;
+    }
+
+    public ExpandableRecyclerAdapter.Holder getHolder() {
+        return holder;
+    }
+
+    public void setHolder(ExpandableRecyclerAdapter.Holder holder) {
+        this.holder = holder;
     }
 }


### PR DESCRIPTION
You can set to true the new oneExpandedMode variable to enabled the mode Only One Group Expanded on the adapter.

If you set this new variable to true when you expand one group, the other expanded group will be collapsed automatically.
