### PR TITLE
Update README.md explaining new functionality One Expanded Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ public abstract T getHolder(View view);
 ```
 - Create two types of elements: one extends ExpandableMenuItem, the other extends ChildMenuItem. Each expandable item can contain zero or more ChildMenuItems
 - Populate the adapter with a list of your expandable items
+- You can set to true the Adapter variable oneExpandedMode to enable "One Expanded Only". This functionality, collapse the current ExpandableMenuItem expanded when you want to expand another. This functionality is deactivated by default.
 - In your "parent item" layout, you can add this 'include' to have an arrow that animates when an item is expanded/collapsed. However, you can use a custom arrow (set its id to img_default_expand_arrow)
 ```xml
 <include layout="@layout/img_default_expand_arrow" />

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
@@ -1,5 +1,3 @@
 package com.tempos21.expandablerecycleradapter;
 
-public abstract class ChildMenuItem extends BaseMenuItem {
-    
-}
+public abstract class ChildMenuItem extends BaseMenuItem { }

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ChildMenuItem.java
@@ -1,3 +1,5 @@
 package com.tempos21.expandablerecycleradapter;
 
-public abstract class ChildMenuItem extends BaseMenuItem { }
+public abstract class ChildMenuItem extends BaseMenuItem {
+    
+}

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableMenuItem.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableMenuItem.java
@@ -8,6 +8,8 @@ public class ExpandableMenuItem extends BaseMenuItem {
 
     private boolean expanded = false;
 
+    private ExpandableRecyclerAdapter.Holder holder;
+
     public ExpandableMenuItem() { }
 
     public ExpandableMenuItem(List<ChildMenuItem> children) {
@@ -32,5 +34,13 @@ public class ExpandableMenuItem extends BaseMenuItem {
 
     public void setChildren(List<ChildMenuItem> children) {
         this.children = children;
+    }
+
+    public ExpandableRecyclerAdapter.Holder getHolder() {
+        return holder;
+    }
+
+    public void setHolder(ExpandableRecyclerAdapter.Holder holder) {
+        this.holder = holder;
     }
 }


### PR DESCRIPTION
Updated README.md with:
- You can set to true the Adapter variable oneExpandedMode to enable "One Expanded Only". This functionality, collapse the current ExpandableMenuItem expanded when you want to expand another. This functionality is deactivated by default.
