### PR TITLE
Add and remove child from parent

### DIFF
--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
@@ -142,13 +142,8 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             items.add(position, childMenuItem);
             notifyItemInserted(position);
         } else {
-            expandableMenuItem.setExpanded(true);
-            items.addAll(position, expandableMenuItem.getChildren());
-            int positionEnd = expandableMenuItem.getChildren().size();
-            notifyItemChanged(getItemPosition(expandableMenuItem));
-            notifyItemRangeInserted(position, positionEnd);
+            expandableMenuItem.getHolder().itemView.performClick();
         }
-
     }
 
     public List<ExpandableMenuItem> getItems() {
@@ -243,7 +238,7 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             }
             item.setExpanded(!item.isExpanded());
         }
-
+        
         private void collapseOthers(int currentPosition) {
             for (int n = 0; n < items.size(); n++) {
                 BaseMenuItem baseMenuItem = items.get(n);
@@ -269,4 +264,5 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             }
         }
     }
+
 }

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
@@ -135,6 +135,22 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
         items.add(newItem);
     }
 
+    public void addChildToParent(ChildMenuItem childMenuItem, ExpandableMenuItem expandableMenuItem) {
+        expandableMenuItem.getChildren().add(0, childMenuItem);
+        int position = getItemPosition(expandableMenuItem) + 1;
+        if (expandableMenuItem.isExpanded()) {
+            items.add(position, childMenuItem);
+            notifyItemInserted(position);
+        } else {
+            expandableMenuItem.setExpanded(true);
+            items.addAll(position, expandableMenuItem.getChildren());
+            int positionEnd = expandableMenuItem.getChildren().size();
+            notifyItemChanged(getItemPosition(expandableMenuItem));
+            notifyItemRangeInserted(position, positionEnd);
+        }
+
+    }
+
     public List<ExpandableMenuItem> getItems() {
         return parentItems;
     }

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
@@ -68,6 +68,7 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             Holder holder = (Holder) tHolder;
             if (holder.imgDefaultExpandArrow != null) {
                 if (expandableMenuItem.hasChildren()) {
+                    updateArrowStatus(expandableMenuItem.isExpanded(), holder.imgDefaultExpandArrow);
                     holder.imgDefaultExpandArrow.setVisibility(View.VISIBLE);
                 } else {
                     holder.imgDefaultExpandArrow.setVisibility(View.INVISIBLE);
@@ -173,6 +174,13 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
         return items.size();
     }
 
+    private void updateArrowStatus(boolean isExpanded, ImageView arrow) {
+        if (isExpanded && arrow != null) {
+            arrow.startAnimation(
+                    AnimationUtils.loadAnimation(context, R.anim.rotation_0_to_180));
+        }
+    }
+
     /*- ********************************************************************************* */
     /*- ********************************************************************************* */
     /*- ********************************************************************************* */
@@ -238,7 +246,7 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             }
             item.setExpanded(!item.isExpanded());
         }
-        
+
         private void collapseOthers(int currentPosition) {
             for (int n = 0; n < items.size(); n++) {
                 BaseMenuItem baseMenuItem = items.get(n);

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
@@ -147,6 +147,17 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
         }
     }
 
+    public void removeChildFromParent(ChildMenuItem childMenuItem, ExpandableMenuItem expandableMenuItem) {
+        int removedPos = getItemPosition(childMenuItem);
+        expandableMenuItem.getChildren().remove(childMenuItem);
+        items.remove(removedPos);
+        notifyItemRemoved(removedPos);
+        if (!expandableMenuItem.hasChildren()) {
+            expandableMenuItem.setExpanded(false);
+            notifyItemChanged(--removedPos);
+        }
+    }
+
     public List<ExpandableMenuItem> getItems() {
         return parentItems;
     }

--- a/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/tempos21/expandablerecycleradapter/ExpandableRecyclerAdapter.java
@@ -18,7 +18,7 @@ import java.util.List;
 public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolder>
         extends RecyclerView.Adapter<T> {
 
-    protected static final int INVALID_POSITION = -1;
+    private static final int INVALID_POSITION = -1;
 
     private static final int VIEW_TYPE_PARENT = 0;
 
@@ -138,12 +138,17 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
 
     public void addChildToParent(ChildMenuItem childMenuItem, ExpandableMenuItem expandableMenuItem) {
         expandableMenuItem.getChildren().add(0, childMenuItem);
-        int position = getItemPosition(expandableMenuItem) + 1;
+        int positionNewChild = getItemPosition(expandableMenuItem) + 1;
         if (expandableMenuItem.isExpanded()) {
-            items.add(position, childMenuItem);
-            notifyItemInserted(position);
+            items.add(positionNewChild, childMenuItem);
+            notifyItemInserted(positionNewChild);
         } else {
-            expandableMenuItem.getHolder().itemView.performClick();
+            if (expandableMenuItem.hasChildren()) {
+                if (oneExpandedMode) {
+                    collapseOthers(getItemPosition(expandableMenuItem));
+                }
+                expandMyself(expandableMenuItem);
+            }
         }
     }
 
@@ -156,6 +161,10 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             expandableMenuItem.setExpanded(false);
             notifyItemChanged(--removedPos);
         }
+    }
+
+    public List<BaseMenuItem> getAllItems() {
+        return items;
     }
 
     public List<ExpandableMenuItem> getItems() {
@@ -189,6 +198,41 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
         if (isExpanded && arrow != null) {
             arrow.startAnimation(
                     AnimationUtils.loadAnimation(context, R.anim.rotation_0_to_180));
+        }
+    }
+
+    private void expandMyself(ExpandableMenuItem item) {
+        int position = getItemPosition(item);
+        items.addAll(position + 1, item.getChildren());
+        notifyItemRangeInserted(position + 1, item.getChildren().size());
+        if (item.getHolder().imgDefaultExpandArrow != null) {
+            item.getHolder().imgDefaultExpandArrow.startAnimation(AnimationUtils.loadAnimation(context, R.anim.rotation_0_to_180));
+        }
+        item.setExpanded(!item.isExpanded());
+    }
+
+    private void collapseOthers(int currentPosition) {
+        for (int n = 0; n < items.size(); n++) {
+            BaseMenuItem baseMenuItem = items.get(n);
+            if (baseMenuItem instanceof ExpandableMenuItem && currentPosition != n) {
+                ExpandableMenuItem expandableMenuItem = (ExpandableMenuItem) baseMenuItem;
+                if (expandableMenuItem.isExpanded()) {
+                    for (int i = 0; i < expandableMenuItem.getChildren().size(); i++) {
+                        items.remove(n + 1);
+                    }
+                    // notifyItemRangeXXX performs an automatic animation :)
+                    notifyItemRangeRemoved(n + 1, expandableMenuItem.getChildren().size());
+                    expandableMenuItem.setExpanded(!expandableMenuItem.isExpanded());
+                    if (expandableMenuItem.getHolder() != null) {
+                        ImageView ivItem = expandableMenuItem.getHolder().imgDefaultExpandArrow;
+                        if (ivItem != null) {
+                            ivItem.startAnimation(
+                                    AnimationUtils.loadAnimation(context, R.anim.rotation_180_to_360));
+                        }
+                    }
+                    return;
+                }
+            }
         }
     }
 
@@ -258,30 +302,6 @@ public abstract class ExpandableRecyclerAdapter<T extends RecyclerView.ViewHolde
             item.setExpanded(!item.isExpanded());
         }
 
-        private void collapseOthers(int currentPosition) {
-            for (int n = 0; n < items.size(); n++) {
-                BaseMenuItem baseMenuItem = items.get(n);
-                if (baseMenuItem instanceof ExpandableMenuItem && currentPosition != n) {
-                    ExpandableMenuItem expandableMenuItem = (ExpandableMenuItem) baseMenuItem;
-                    if (expandableMenuItem.isExpanded()) {
-                        for (int i = 0; i < expandableMenuItem.getChildren().size(); i++) {
-                            items.remove(n + 1);
-                        }
-                        // notifyItemRangeXXX performs an automatic animation :)
-                        notifyItemRangeRemoved(n + 1, expandableMenuItem.getChildren().size());
-                        expandableMenuItem.setExpanded(!expandableMenuItem.isExpanded());
-                        if (expandableMenuItem.getHolder() != null) {
-                            ImageView ivItem = expandableMenuItem.getHolder().imgDefaultExpandArrow;
-                            if (ivItem != null) {
-                                ivItem.startAnimation(
-                                        AnimationUtils.loadAnimation(context, R.anim.rotation_180_to_360));
-                            }
-                        }
-                        return;
-                    }
-                }
-            }
-        }
     }
 
 }


### PR DESCRIPTION
Added posibility to add or remove a ChildMenuItem from the ExpandableMenuItem on the adapter.
Show arrow as expandad when onBindViewHolder is called to print the Header again.